### PR TITLE
gemfileにrails-i18n-7.0.6を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'devise'
 
-gem 'rails-i18n'
+gem 'rails-i18n', '7.0.6'
 
 group :development, :test do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.


### PR DESCRIPTION
変更点
・gem 'rails-i18n', '7.0.6'をgemfileに追記

理由
gem 'rails-i18n'のバージョンを指定していなかったところ、本番環境でのasset precompile時に
Could not find rails-i18n-7.0.6 in locally installed gems
Run `bundle install` to install missing gems.
とエラーが出力されたため。